### PR TITLE
fix: add error listener to ssdp

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "test:node": "aegir test -t node"
   },
   "dependencies": {
-    "@achingbrain/ssdp": "^3.0.1",
+    "@achingbrain/ssdp": "^4.0.0",
     "@libp2p/logger": "^1.0.4",
     "default-gateway": "^6.0.2",
     "err-code": "^3.0.1",

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -77,6 +77,9 @@ export function discoverGateway (options: DiscoveryOptions = {}): () => Discover
         } else {
           if (discovery == null) {
             discovery = await ssdp()
+            discovery.on('error', (err) => {
+              log.error('ssdp error', err)
+            })
           }
 
           log('Discovering gateway')


### PR DESCRIPTION
The ssdp module can emit an error during discovery so add a listener for that event