### PR TITLE
fix: shut down cleanly

### DIFF
--- a/package.json
+++ b/package.json
@@ -138,7 +138,7 @@
     "test:node": "aegir test -t node"
   },
   "dependencies": {
-    "@achingbrain/ssdp": "^4.0.0",
+    "@achingbrain/ssdp": "^4.0.1",
     "@libp2p/logger": "^1.0.4",
     "default-gateway": "^6.0.2",
     "err-code": "^3.0.1",

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -76,10 +76,13 @@ export function discoverGateway (options: DiscoveryOptions = {}): () => Discover
           }
         } else {
           if (discovery == null) {
-            discovery = await ssdp()
+            discovery = await ssdp({
+              start: false
+            })
             discovery.on('error', (err) => {
               log.error('ssdp error', err)
             })
+            await discovery.start()
           }
 
           log('Discovering gateway')

--- a/src/upnp/device.ts
+++ b/src/upnp/device.ts
@@ -39,7 +39,7 @@ export class Device {
     ]
   }
 
-  async run (action: string, args: Array<[string, string | number]>) {
+  async run (action: string, args: Array<[string, string | number]>, signal: AbortSignal) {
     const info = this.getService(this.services)
 
     const requestBody = `<?xml version="1.0"?>
@@ -61,7 +61,8 @@ export class Device {
         'Content-Length': requestBody.length.toString(),
         SOAPAction: JSON.stringify(info.service + '#' + action)
       },
-      body: requestBody
+      body: requestBody,
+      signal
     })
 
     log.trace('<-', text)

--- a/src/upnp/fetch.ts
+++ b/src/upnp/fetch.ts
@@ -7,20 +7,23 @@ const log = logger('nat-port-mapper:upnp:fetch')
 export interface RequestInit {
   method: 'POST' | 'GET'
   headers: Record<string, string>
-  body: Buffer | string
+  body: Buffer | string,
+  signal: AbortSignal
 }
 
 function initRequest (url: URL, init: RequestInit) {
   if (url.protocol === 'http:') {
     return http.request(url, {
       method: init.method,
-      headers: init.headers
+      headers: init.headers,
+      signal: init.signal
     })
   } else if (url.protocol === 'https:') {
     return https.request(url, {
       method: init.method,
       headers: init.headers,
-      rejectUnauthorized: false
+      rejectUnauthorized: false,
+      signal: init.signal
     })
   } else {
     throw new Error('Invalid protocol ' + url.protocol)

--- a/src/upnp/fetch.ts
+++ b/src/upnp/fetch.ts
@@ -7,7 +7,7 @@ const log = logger('nat-port-mapper:upnp:fetch')
 export interface RequestInit {
   method: 'POST' | 'GET'
   headers: Record<string, string>
-  body: Buffer | string,
+  body: Buffer | string
   signal: AbortSignal
 }
 


### PR DESCRIPTION
Use an abort controller to abort in-flight requests, also split starting the ssdp bus from creating it so we can shut it down before it finishes starting up.