### PR TITLE
fix: replace err-code with CodeError

### DIFF
--- a/package.json
+++ b/package.json
@@ -142,7 +142,6 @@
     "@libp2p/interfaces": "^3.3.1",
     "@libp2p/logger": "^2.0.0",
     "default-gateway": "^6.0.2",
-    "err-code": "^3.0.1",
     "it-first": "^1.0.7",
     "p-defer": "^4.0.0",
     "p-timeout": "^5.0.2",

--- a/package.json
+++ b/package.json
@@ -139,6 +139,7 @@
   },
   "dependencies": {
     "@achingbrain/ssdp": "^4.0.1",
+    "@libp2p/interfaces": "^3.3.1",
     "@libp2p/logger": "^2.0.0",
     "default-gateway": "^6.0.2",
     "err-code": "^3.0.1",

--- a/src/pmp/index.ts
+++ b/src/pmp/index.ts
@@ -1,7 +1,7 @@
 import { createSocket } from 'dgram'
 import { logger } from '@libp2p/logger'
 import { EventEmitter } from 'events'
-import errCode from 'err-code'
+import { CodeError } from '@libp2p/interfaces/errors'
 import defer, { DeferredPromise } from 'p-defer'
 import type { Socket, RemoteInfo } from 'dgram'
 import type { Client, MapPortOptions, UnmapPortOptions } from '../index.js'
@@ -341,7 +341,7 @@ export class PMPClient extends EventEmitter implements Client {
 
     // Error
     if (parsed.resultCode !== 0) {
-      return cb(errCode(new Error(parsed.resultMessage), parsed.resultCode))
+      return cb(new CodeError(parsed.resultMessage, parsed.resultCode))
     }
 
     // Success


### PR DESCRIPTION
Related: https://github.com/libp2p/js-libp2p/issues/1269

- deps: install @libp2p/interfaces
- fix: replace err-code with CodeError
- deps: remove err-code
