### PR TITLE
chore(deps): Updated xml2js to 0.5.0 to patch CVE-2023-0842

### DIFF
--- a/package.json
+++ b/package.json
@@ -145,11 +145,11 @@
     "it-first": "^1.0.7",
     "p-defer": "^4.0.0",
     "p-timeout": "^5.0.2",
-    "xml2js": "^0.4.23"
+    "xml2js": "^0.5.0"
   },
   "devDependencies": {
     "@types/default-gateway": "^3.0.1",
-    "@types/xml2js": "^0.4.9",
+    "@types/xml2js": "^0.4.11",
     "aegir": "^37.0.15"
   }
 }


### PR DESCRIPTION
Fixes a [recently published vulnerability](https://github.com/advisories/GHSA-776f-qx25-q3cc) which was patched in [0.5.0](https://github.com/Leonidas-from-XIV/node-xml2js/issues/663#issuecomment-1501088667)