### PR TITLE
fix: expose mapped ports on client object

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -41,13 +41,13 @@ export interface Client {
 }
 
 export class NatAPI {
+  public openPorts: MapPortOptions[]
   private readonly ttl: number
   private readonly description: string
   private readonly gateway?: string
   private readonly keepAlive: boolean
   private readonly keepAliveInterval: number
   private readonly destroyed: boolean
-  private openPorts: MapPortOptions[]
   private readonly client: Client
   private readonly updateIntervals: Map<string, any>
 


### PR DESCRIPTION
Expose the `openPorts` field for inspection.