### PR TITLE
fix: add required NewRemoteHost field

### DIFF
--- a/src/upnp/index.ts
+++ b/src/upnp/index.ts
@@ -44,6 +44,7 @@ export class UPNPClient implements Client {
     log('Mapping local port %d to public port %d', options.localPort, options.publicPort)
 
     await gateway.run('AddPortMapping', [
+      ['NewRemoteHost', ''],
       ['NewExternalPort', options.publicPort],
       ['NewProtocol', protocol],
       ['NewInternalPort', options.localPort],
@@ -63,6 +64,7 @@ export class UPNPClient implements Client {
     const gateway = await this.findGateway()
 
     await gateway.run('DeletePortMapping', [
+      ['NewRemoteHost', ''],
       ['NewExternalPort', options.publicPort],
       ['NewProtocol', options.protocol]
     ], this.abortController.signal)


### PR DESCRIPTION
My TP-Link AC1750 always responds with a 500 error to UPnP requests unless the `NewRemoteHost` field is included. It doesn't actually seem to be used, but just has to exist (or I guess an empty value is actually a wildcard according to https://upnp.org/specs/gw/UPnP-gw-WANIPConnection-v1-Service.pdf).