### PR TITLE
feat!: accept abort signals during operations

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,6 +3,6 @@ on: [ pull_request ]
 
 jobs:
   automerge:
-    uses: protocol/.github/.github/workflows/automerge.yml@master
+    uses: protocol/.github/.github/workflows/automerge.yml@main
     with:
       job: 'automerge'

--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -3,6 +3,6 @@ on: [ pull_request ]
 
 jobs:
   automerge:
-    uses: protocol/.github/.github/workflows/automerge.yml@main
+    uses: protocol/.github/.github/workflows/automerge.yml@master
     with:
       job: 'automerge'

--- a/package.json
+++ b/package.json
@@ -147,7 +147,7 @@
   "dependencies": {
     "@achingbrain/ssdp": "^4.1.0",
     "@libp2p/logger": "^5.0.1",
-    "abort-options": "^1.0.1",
+    "abort-error": "^1.0.0",
     "any-signal": "^4.1.1",
     "default-gateway": "^7.2.2",
     "err-code": "^3.0.1",

--- a/package.json
+++ b/package.json
@@ -146,7 +146,6 @@
   },
   "dependencies": {
     "@achingbrain/ssdp": "^4.1.0",
-    "@libp2p/interface": "^2.2.0",
     "@libp2p/logger": "^5.0.1",
     "abort-options": "^1.0.1",
     "any-signal": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -141,17 +141,20 @@
     "build": "aegir build --no-bundle",
     "docs": "aegir docs",
     "release": "aegir release",
-    "test": "aegir test",
+    "test": "aegir test -t node",
     "test:node": "aegir test -t node"
   },
   "dependencies": {
-    "@achingbrain/ssdp": "^4.0.1",
+    "@achingbrain/ssdp": "^4.1.0",
+    "@libp2p/interface": "^2.2.0",
     "@libp2p/logger": "^5.0.1",
+    "abort-options": "^1.0.1",
+    "any-signal": "^4.1.1",
     "default-gateway": "^7.2.2",
     "err-code": "^3.0.1",
     "it-first": "^3.0.1",
     "p-defer": "^4.0.0",
-    "p-timeout": "^6.1.1",
+    "race-signal": "^1.1.0",
     "xml2js": "^0.6.0"
   },
   "devDependencies": {

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -5,7 +5,7 @@ import { anySignal } from 'any-signal'
 import first from 'it-first'
 import type { InternetGatewayDevice } from '../upnp/device'
 import type { Service, SSDP } from '@achingbrain/ssdp'
-import type { AbortOptions } from 'abort-options'
+import type { AbortOptions } from 'abort-error'
 
 const log = logger('nat-port-mapper:discovery')
 

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,5 +1,5 @@
 import ssdp from '@achingbrain/ssdp'
-import { setMaxListeners } from '@libp2p/interface'
+import { setMaxListeners } from 'node:events'
 import { logger } from '@libp2p/logger'
 import { anySignal } from 'any-signal'
 import first from 'it-first'

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,15 +1,17 @@
 import ssdp from '@achingbrain/ssdp'
+import { setMaxListeners } from '@libp2p/interface'
 import { logger } from '@libp2p/logger'
+import { anySignal } from 'any-signal'
 import first from 'it-first'
-import pTimeout from 'p-timeout'
 import type { InternetGatewayDevice } from '../upnp/device'
 import type { Service, SSDP } from '@achingbrain/ssdp'
+import type { AbortOptions } from 'abort-options'
 
 const log = logger('nat-port-mapper:discovery')
 
 export interface DiscoverGateway {
-  gateway(): Promise<Service<InternetGatewayDevice>>
-  cancel(): Promise<void>
+  gateway(options?: AbortOptions): Promise<Service<InternetGatewayDevice>>
+  cancel(options?: AbortOptions): Promise<void>
 }
 
 export interface DiscoveryOptions {
@@ -22,11 +24,6 @@ export interface DiscoveryOptions {
    * Rediscover gateway after this number of ms
    */
   timeout?: number
-
-  /**
-   * Only search the network for this long
-   */
-  discoveryTimeout?: number
 }
 
 const ST = 'urn:schemas-upnp-org:device:InternetGatewayDevice:1'
@@ -35,22 +32,22 @@ const ONE_HOUR = ONE_MINUTE * 60
 
 export function discoverGateway (options: DiscoveryOptions = {}): () => DiscoverGateway {
   const timeout = options.timeout ?? ONE_HOUR
-  const discoveryTimeout = options.discoveryTimeout ?? ONE_MINUTE
   let service: Service<InternetGatewayDevice>
   let expires: number
+  const shutdownController = new AbortController()
+  setMaxListeners(Infinity, shutdownController.signal)
 
   return () => {
-    let discovery: SSDP
-    let clear: (() => void) | undefined
-
     const discover: DiscoverGateway = {
-      gateway: async () => {
+      gateway: async (opts?: AbortOptions) => {
+        opts?.signal?.throwIfAborted()
+
         if (service != null && !(expires < Date.now())) {
           return service
         }
 
         if (options.gateway != null) {
-          log('Using overridden gateway address %s', options.gateway)
+          log('using overridden gateway address %s', options.gateway)
 
           if (!options.gateway.startsWith('http')) {
             options.gateway = `http://${options.gateway}`
@@ -75,45 +72,43 @@ export function discoverGateway (options: DiscoveryOptions = {}): () => Discover
             uniqueServiceName: 'unknown'
           }
         } else {
-          if (discovery == null) {
-            discovery = await ssdp({
-              start: false
+          log('create discovery')
+          let discovery: SSDP | undefined
+
+          try {
+            discovery = await ssdp()
+            discovery.on('transport:outgoing-message', (socket, message, remote) => {
+              log.trace('-> Outgoing to %s:%s via %s - %s', remote.address, remote.port, socket.type, message)
             })
-            discovery.on('error', (err) => {
-              log.error('ssdp error', err)
+            discovery.on('transport:incoming-message', (message, remote) => {
+              log.trace('<- Incoming from %s:%s - %s', remote.address, remote.port, message)
             })
-            await discovery.start()
+
+            const signal = anySignal([shutdownController.signal, opts?.signal])
+            setMaxListeners(Infinity, signal)
+
+            const result = await first(discovery.discover<InternetGatewayDevice>({
+              serviceType: ST,
+              signal
+            }))
+
+            if (result == null) {
+              throw new Error('Could not discover gateway')
+            }
+
+            log('discovered gateway %s', result.location)
+
+            expires = Date.now() + timeout
+            service = result
+          } finally {
+            await discovery?.stop()
           }
-
-          log('Discovering gateway')
-          const clearable = pTimeout(first(discovery.discover<InternetGatewayDevice>(ST)), {
-            milliseconds: discoveryTimeout
-          })
-
-          clear = clearable.clear
-
-          const result = await clearable
-
-          if (result == null) {
-            throw new Error('Could not discover gateway')
-          }
-
-          log('Discovered gateway %s', result.location)
-
-          service = result
-          expires = Date.now() + timeout
         }
 
         return service
       },
       cancel: async () => {
-        if (discovery != null) {
-          await discovery.stop()
-        }
-
-        if (clear != null) {
-          clear()
-        }
+        shutdownController.abort()
       }
     }
 

--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,5 +1,5 @@
-import ssdp from '@achingbrain/ssdp'
 import { setMaxListeners } from 'node:events'
+import ssdp from '@achingbrain/ssdp'
 import { logger } from '@libp2p/logger'
 import { anySignal } from 'any-signal'
 import first from 'it-first'

--- a/src/index.ts
+++ b/src/index.ts
@@ -59,6 +59,8 @@ import { gateway4async } from 'default-gateway'
 import { discoverGateway } from './discovery/index.js'
 import { PMPClient } from './pmp/index.js'
 import { UPNPClient } from './upnp/index.js'
+import type { Client } from './types.js'
+import type { AbortOptions } from 'abort-options'
 
 const log = logger('nat-port-mapper')
 
@@ -69,32 +71,126 @@ export interface NatAPIOptions {
    * @default 7200
    */
   ttl?: number
+
+  /**
+   * If passed this will be used as the default description when mapping ports
+   *
+   * @default '@achingbrain/nat-port-mapper'
+   */
   description?: string
+
+  /**
+   * If a gateway is known, pass it here, otherwise one will be discovered on
+   * the network
+   */
   gateway?: string
+
+  /**
+   * If true, any mapped ports will be refreshed when their lease expires
+   *
+   * @default true
+   */
   keepAlive?: boolean
 }
 
-export interface MapPortOptions {
+export interface MapPortOptions extends AbortOptions {
+  /**
+   * The external port to map
+   */
   publicPort: number
+
+  /**
+   * The external host to map or '' as a wildcard
+   *
+   * @default ''
+   */
+  publicHost?: string
+
+  /**
+   * The local port to map
+   */
   localPort: number
+
+  /**
+   * The local address to map
+   */
   localAddress: string
+
+  /**
+   * The protocol the port uses
+   */
   protocol: 'TCP' | 'UDP'
+
+  /**
+   * Some metadata about the mapping
+   */
   description: string
+
+  /**
+   * How long to map the port for
+   */
   ttl: number
+
+  /**
+   * A gateway to map the port on, if omitted
+   */
   gateway?: string
 }
 
-export interface UnmapPortOptions {
+export interface UnmapPortOptions extends AbortOptions {
+  /**
+   * The external port to unmap
+   */
   publicPort: number
+
+  /**
+   * The external host to unmap or '' as a wildcard
+   *
+   * @default ''
+   */
+  publicHost?: string
+
+  /**
+   * The local port to unmap
+   */
   localPort: number
+
+  /**
+   * The local address to unmap
+   */
+  localAddress: string
+
+  /**
+   * The protocol the port uses
+   */
   protocol: 'TCP' | 'UDP'
+
+  /**
+   * A gateway to unmap the port on
+   */
+  gateway?: string
 }
 
-export interface Client {
-  close(): Promise<void>
+export interface NatAPI {
+  /**
+   * Stop all network transactions and unmap any mapped ports
+   */
+  close(options?: AbortOptions): Promise<void>
+
+  /**
+   * Map a local port to one on the external network interface
+   */
   map(options: MapPortOptions): Promise<void>
+
+  /**
+   * Unmap a previously mapped port
+   */
   unmap(options: UnmapPortOptions): Promise<void>
-  externalIp(): Promise<string>
+
+  /**
+   * Find the external network IP address
+   */
+  externalIp(options?: AbortOptions): Promise<string>
 }
 
 export class NatAPI {
@@ -111,7 +207,7 @@ export class NatAPI {
   constructor (opts: NatAPIOptions = {}, client: Client) {
     // TTL is 2 hours (min 60 secs, default 2 hours)
     this.ttl = opts.ttl != null ? Math.max(opts.ttl, 60) : 7200
-    this.description = opts.description ?? 'NatAPI'
+    this.description = opts.description ?? '@achingbrain/nat-port-mapper'
     this.gateway = opts.gateway
     this.keepAlive = opts.keepAlive ?? true
     this.client = client
@@ -140,12 +236,12 @@ export class NatAPI {
       this.updateIntervals.set(`${opts.publicPort}:${opts.localPort}-${opts.protocol}`, setInterval(() => {
         void this.client.map(opts)
           .catch(err => {
-            log('Error refreshing port mapping %d:%d for protocol %s mapped on router', opts.publicPort, opts.localPort, opts.protocol, err)
+            log('error refreshing port mapping %d:%d for protocol %s mapped on router - %e', opts.publicPort, opts.localPort, opts.protocol, err)
           })
       }, this.keepAliveInterval))
     }
 
-    log('Port %d:%d for protocol %s mapped on router', opts.publicPort, opts.localPort, opts.protocol)
+    log('port %d:%d for protocol %s mapped on router', opts.publicPort, opts.localPort, opts.protocol)
   }
 
   async unmap (options: Partial<UnmapPortOptions>): Promise<void> {
@@ -167,17 +263,12 @@ export class NatAPI {
     clearInterval(this.updateIntervals.get(key))
     this.updateIntervals.delete(key)
 
-    log('Port %d:%d for protocol %s unmapped on router', opts.publicPort, opts.localPort, opts.protocol)
+    log('port %d:%d for protocol %s unmapped on router', opts.publicPort, opts.localPort, opts.protocol)
   }
 
-  async close (): Promise<void> {
+  async close (options?: AbortOptions): Promise<void> {
     if (this.destroyed) {
       throw new Error('client already closed')
-    }
-
-    if (this.client != null) {
-      log('Close UPnP client')
-      await this.client.close()
     }
 
     // stop all updates
@@ -186,13 +277,22 @@ export class NatAPI {
     }
     this.updateIntervals.clear()
 
-    // Unmap all ports
+    // unmap all ports
     await Promise.all(
-      this.openPorts.map(async opts => this.unmap(opts))
+      this.openPorts.map(async opts => this.unmap({
+        ...options,
+        ...opts
+      }))
     )
+
+    // finally close the client
+    if (this.client != null) {
+      log('close UPnP client')
+      await this.client.close(options)
+    }
   }
 
-  validateInput (options: Partial<MapPortOptions> = {}): MapPortOptions {
+  private validateInput (options: Partial<MapPortOptions> = {}): MapPortOptions {
     if (options.localPort == null) {
       throw new Error('invalid parameters')
     }
@@ -204,14 +304,15 @@ export class NatAPI {
       protocol: options.protocol ?? 'TCP',
       description: options.description ?? this.description,
       ttl: options.ttl ?? this.ttl,
-      gateway: options.gateway ?? this.gateway
+      gateway: options.gateway ?? this.gateway,
+      signal: options.signal
     }
 
     return output
   }
 
-  async externalIp (): Promise<string> {
-    return this.client.externalIp()
+  async externalIp (options?: AbortOptions): Promise<string> {
+    return this.client.externalIp(options)
   }
 }
 
@@ -232,7 +333,7 @@ function findLocalAddress (): string {
         continue
       }
 
-      log('Found local address', info.address)
+      log('found local address', info.address)
       return info.address
     }
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -60,7 +60,7 @@ import { discoverGateway } from './discovery/index.js'
 import { PMPClient } from './pmp/index.js'
 import { UPNPClient } from './upnp/index.js'
 import type { Client } from './types.js'
-import type { AbortOptions } from 'abort-options'
+import type { AbortOptions } from 'abort-error'
 
 const log = logger('nat-port-mapper')
 

--- a/src/pmp/index.ts
+++ b/src/pmp/index.ts
@@ -7,7 +7,7 @@ import { raceSignal } from 'race-signal'
 import type { DiscoverGateway } from '../discovery/index.js'
 import type { MapPortOptions, UnmapPortOptions } from '../index.js'
 import type { Client } from '../types.js'
-import type { AbortOptions } from 'abort-options'
+import type { AbortOptions } from 'abort-error'
 import type { Socket, RemoteInfo } from 'dgram'
 
 const debug = logger('nat-port-mapper:pmp')

--- a/src/pmp/index.ts
+++ b/src/pmp/index.ts
@@ -3,8 +3,11 @@ import { EventEmitter } from 'events'
 import { logger } from '@libp2p/logger'
 import errCode from 'err-code'
 import defer, { type DeferredPromise } from 'p-defer'
+import { raceSignal } from 'race-signal'
 import type { DiscoverGateway } from '../discovery/index.js'
-import type { Client, MapPortOptions, UnmapPortOptions } from '../index.js'
+import type { MapPortOptions, UnmapPortOptions } from '../index.js'
+import type { Client } from '../types.js'
+import type { AbortOptions } from 'abort-options'
 import type { Socket, RemoteInfo } from 'dgram'
 
 const debug = logger('nat-port-mapper:pmp')
@@ -19,7 +22,7 @@ const OP_MAP_UDP = 1
 const OP_MAP_TCP = 2
 const SERVER_DELTA = 128
 
-// Resulit codes
+// Result codes
 const RESULT_CODES: Record<number, string> = {
   0: 'Success',
   1: 'Unsupported Version',
@@ -47,7 +50,7 @@ export class PMPClient extends EventEmitter implements Client {
   private reqActive: boolean
   private readonly discoverGateway: () => DiscoverGateway
   private gateway?: string
-  private cancelGatewayDiscovery?: () => Promise<void>
+  private cancelGatewayDiscovery?: (options?: AbortOptions) => Promise<void>
 
   static createClient (discoverGateway: () => DiscoverGateway): PMPClient {
     return new PMPClient(discoverGateway)
@@ -102,7 +105,7 @@ export class PMPClient extends EventEmitter implements Client {
     const discoverGateway = this.discoverGateway()
     this.cancelGatewayDiscovery = discoverGateway.cancel
 
-    const gateway = await discoverGateway.gateway()
+    const gateway = await discoverGateway.gateway(opts)
     this.cancelGatewayDiscovery = undefined
 
     this.gateway = new URL(gateway.location).host
@@ -111,7 +114,7 @@ export class PMPClient extends EventEmitter implements Client {
 
     this.request(opcode, opts, deferred)
 
-    await deferred.promise
+    await raceSignal(deferred.promise, opts.signal)
   }
 
   async unmap (opts: UnmapPortOptions): Promise<void> {
@@ -125,13 +128,13 @@ export class PMPClient extends EventEmitter implements Client {
     })
   }
 
-  async externalIp (): Promise<string> {
+  async externalIp (options?: AbortOptions): Promise<string> {
     debug('Client#externalIp()')
 
     const discoverGateway = this.discoverGateway()
     this.cancelGatewayDiscovery = discoverGateway.cancel
 
-    const gateway = await discoverGateway.gateway()
+    const gateway = await discoverGateway.gateway(options)
     this.cancelGatewayDiscovery = undefined
 
     this.gateway = new URL(gateway.location).host
@@ -143,7 +146,7 @@ export class PMPClient extends EventEmitter implements Client {
     return deferred.promise
   }
 
-  async close (): Promise<void> {
+  async close (options?: AbortOptions): Promise<void> {
     debug('Client#close()')
 
     if (this.socket != null) {
@@ -157,7 +160,7 @@ export class PMPClient extends EventEmitter implements Client {
     this.reqActive = false
 
     if (this.cancelGatewayDiscovery != null) {
-      await this.cancelGatewayDiscovery()
+      await this.cancelGatewayDiscovery(options)
     }
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,9 @@
+import type { MapPortOptions, UnmapPortOptions } from './index.js'
+import type { AbortOptions } from 'abort-options'
+
+export interface Client {
+  close(options?: AbortOptions): Promise<void>
+  map(options: MapPortOptions): Promise<void>
+  unmap(options: UnmapPortOptions): Promise<void>
+  externalIp(options?: AbortOptions): Promise<string>
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,5 @@
 import type { MapPortOptions, UnmapPortOptions } from './index.js'
-import type { AbortOptions } from 'abort-options'
+import type { AbortOptions } from 'abort-error'
 
 export interface Client {
   close(options?: AbortOptions): Promise<void>

--- a/src/upnp/fetch.ts
+++ b/src/upnp/fetch.ts
@@ -46,7 +46,7 @@ export async function fetchXML (url: URL, init: RequestInit): Promise<string> {
 
     request.on('response', (response) => {
       if (response.statusCode === 302 && response.headers.location != null) {
-        log('Redirecting to %s', response.headers.location)
+        log('redirecting to %s', response.headers.location)
         fetchXML(new URL(response.headers.location), init)
           .then(resolve, reject)
         return

--- a/src/upnp/index.ts
+++ b/src/upnp/index.ts
@@ -3,7 +3,7 @@ import { Device } from './device.js'
 import type { DiscoverGateway } from '../discovery/index.js'
 import type { MapPortOptions, UnmapPortOptions } from '../index.js'
 import type { Client } from '../types.js'
-import type { AbortOptions } from 'abort-options'
+import type { AbortOptions } from 'abort-error'
 
 const log = logger('nat-port-mapper:upnp')
 

--- a/src/upnp/index.ts
+++ b/src/upnp/index.ts
@@ -1,15 +1,17 @@
 import { logger } from '@libp2p/logger'
 import { Device } from './device.js'
 import type { DiscoverGateway } from '../discovery/index.js'
-import type { Client, MapPortOptions, UnmapPortOptions } from '../index.js'
+import type { MapPortOptions, UnmapPortOptions } from '../index.js'
+import type { Client } from '../types.js'
+import type { AbortOptions } from 'abort-options'
 
 const log = logger('nat-port-mapper:upnp')
 
 export class UPNPClient implements Client {
   private closed: boolean
   private readonly discoverGateway: () => DiscoverGateway
-  private cancelGatewayDiscovery?: () => Promise<void>
-  private readonly abortController: AbortController
+  private cancelGatewayDiscovery?: (options?: AbortOptions) => Promise<void>
+  private readonly shutdownController: AbortController
 
   static createClient (discoverGateway: () => DiscoverGateway): UPNPClient {
     return new UPNPClient(discoverGateway)
@@ -20,7 +22,7 @@ export class UPNPClient implements Client {
     this.closed = false
 
     // used to terminate network operations on shutdown
-    this.abortController = new AbortController()
+    this.shutdownController = new AbortController()
   }
 
   async map (options: MapPortOptions): Promise<void> {
@@ -41,10 +43,10 @@ export class UPNPClient implements Client {
       ttl = Number(options.ttl)
     }
 
-    log('Mapping local port %d to public port %d', options.localPort, options.publicPort)
+    log('mapping local port %d to public port %d', options.localPort, options.publicPort)
 
     await gateway.run('AddPortMapping', [
-      ['NewRemoteHost', ''],
+      ['NewRemoteHost', options.publicHost ?? ''],
       ['NewExternalPort', options.publicPort],
       ['NewProtocol', protocol],
       ['NewInternalPort', options.localPort],
@@ -53,7 +55,7 @@ export class UPNPClient implements Client {
       ['NewPortMappingDescription', description],
       ['NewLeaseDuration', ttl],
       ['NewProtocol', options.protocol]
-    ], this.abortController.signal)
+    ], this.shutdownController.signal)
   }
 
   async unmap (options: UnmapPortOptions): Promise<void> {
@@ -64,21 +66,22 @@ export class UPNPClient implements Client {
     const gateway = await this.findGateway()
 
     await gateway.run('DeletePortMapping', [
-      ['NewRemoteHost', ''],
+      ['NewRemoteHost', options.publicHost ?? ''],
       ['NewExternalPort', options.publicPort],
       ['NewProtocol', options.protocol]
-    ], this.abortController.signal)
+    ], this.shutdownController.signal)
   }
 
-  async externalIp (): Promise<string> {
+  async externalIp (options?: AbortOptions): Promise<string> {
     if (this.closed) {
       throw new Error('client is closed')
     }
 
-    log('Discover external IP address')
+    log('discover external IP address')
 
-    const gateway = await this.findGateway()
-    const data = await gateway.run('GetExternalIPAddress', [], this.abortController.signal)
+    const gateway = await this.findGateway(options)
+
+    const data = await gateway.run('GetExternalIPAddress', [], this.shutdownController.signal)
 
     let key = null
     Object.keys(data).some(function (k) {
@@ -92,11 +95,11 @@ export class UPNPClient implements Client {
       throw new Error('Incorrect response')
     }
 
-    log('Discovered external IP address %s', data[key].NewExternalIPAddress)
+    log('discovered external IP address %s', data[key].NewExternalIPAddress)
     return data[key].NewExternalIPAddress
   }
 
-  async findGateway (): Promise<Device> {
+  async findGateway (options?: AbortOptions): Promise<Device> {
     if (this.closed) {
       throw new Error('client is closed')
     }
@@ -104,20 +107,20 @@ export class UPNPClient implements Client {
     const discovery = this.discoverGateway()
     this.cancelGatewayDiscovery = discovery.cancel
 
-    const service = await discovery.gateway()
+    const service = await discovery.gateway(options)
 
     this.cancelGatewayDiscovery = undefined
 
     return new Device(service)
   }
 
-  async close (): Promise<void> {
+  async close (options?: AbortOptions): Promise<void> {
     this.closed = true
 
-    this.abortController.abort()
+    this.shutdownController.abort()
 
     if (this.cancelGatewayDiscovery != null) {
-      await this.cancelGatewayDiscovery()
+      await this.cancelGatewayDiscovery(options)
     }
   }
 }


### PR DESCRIPTION
To modernise the API, accept `AbortSignal`s when performing long lived operations that return promises.

Also fixes #72

BREAKING CHANGE: the global `discoveryTimeout` option has been removed, instead pass an AbortSignal to the operation