### PR TITLE
fix: increase max listeners on shutdown controller signal

### DIFF
--- a/src/upnp/index.ts
+++ b/src/upnp/index.ts
@@ -24,6 +24,7 @@ export class UPNPClient implements Client {
 
     // used to terminate network operations on shutdown
     this.shutdownController = new AbortController()
+    setMaxListeners(Infinity, this.shutdownController.signal)
   }
 
   async map (localPort: number, options: InternalMapOptions): Promise<number> {


### PR DESCRIPTION
To prevent warnings around too many listeners, increase the max allowed listeners.