### PR TITLE
fix: use signals for aborting gateway search

### DIFF
--- a/src/discovery/index.ts
+++ b/src/discovery/index.ts
@@ -1,7 +1,5 @@
-import { setMaxListeners } from 'node:events'
 import ssdp from '@achingbrain/ssdp'
 import { logger } from '@libp2p/logger'
-import { anySignal } from 'any-signal'
 import first from 'it-first'
 import type { InternetGatewayDevice } from '../upnp/device'
 import type { Service, SSDP } from '@achingbrain/ssdp'
@@ -10,8 +8,7 @@ import type { AbortOptions } from 'abort-error'
 const log = logger('nat-port-mapper:discovery')
 
 export interface DiscoverGateway {
-  gateway(options?: AbortOptions): Promise<Service<InternetGatewayDevice>>
-  cancel(options?: AbortOptions): Promise<void>
+  (options?: AbortOptions): Promise<Service<InternetGatewayDevice>>
 }
 
 export interface DiscoveryOptions extends AbortOptions {
@@ -33,86 +30,72 @@ const ONE_HOUR = ONE_MINUTE * 60
 export function discoverGateway (): () => DiscoverGateway {
   let service: Service<InternetGatewayDevice>
   let expires: number
-  const shutdownController = new AbortController()
-  setMaxListeners(Infinity, shutdownController.signal)
 
-  return () => {
-    const discover: DiscoverGateway = {
-      gateway: async (options?: DiscoveryOptions) => {
-        options?.signal?.throwIfAborted()
+  return (): DiscoverGateway => {
+    return async (options?: DiscoveryOptions) => {
+      const timeout = options?.timeout ?? ONE_HOUR
 
-        const timeout = options?.timeout ?? ONE_HOUR
+      if (service != null && !(expires < Date.now())) {
+        return service
+      }
 
-        if (service != null && !(expires < Date.now())) {
-          return service
+      if (options?.gateway != null) {
+        log('using overridden gateway address %s', options.gateway)
+
+        if (!options.gateway.startsWith('http')) {
+          options.gateway = `http://${options.gateway}`
         }
 
-        if (options?.gateway != null) {
-          log('using overridden gateway address %s', options.gateway)
+        expires = Date.now() + timeout
 
-          if (!options.gateway.startsWith('http')) {
-            options.gateway = `http://${options.gateway}`
+        service = {
+          location: new URL(options.gateway),
+          details: {
+            device: {
+              serviceList: {
+                service: []
+              },
+              deviceList: {
+                device: []
+              }
+            }
+          },
+          expires,
+          serviceType: ST,
+          uniqueServiceName: 'unknown'
+        }
+      } else {
+        log('create discovery')
+        let discovery: SSDP | undefined
+
+        try {
+          discovery = await ssdp()
+          discovery.on('transport:outgoing-message', (socket, message, remote) => {
+            log.trace('-> Outgoing to %s:%s via %s - %s', remote.address, remote.port, socket.type, message)
+          })
+          discovery.on('transport:incoming-message', (message, remote) => {
+            log.trace('<- Incoming from %s:%s - %s', remote.address, remote.port, message)
+          })
+
+          const result = await first(discovery.discover<InternetGatewayDevice>({
+            ...options,
+            serviceType: ST
+          }))
+
+          if (result == null) {
+            throw new Error('Could not discover gateway')
           }
+
+          log('discovered gateway %s', result.location)
 
           expires = Date.now() + timeout
-
-          service = {
-            location: new URL(options.gateway),
-            details: {
-              device: {
-                serviceList: {
-                  service: []
-                },
-                deviceList: {
-                  device: []
-                }
-              }
-            },
-            expires,
-            serviceType: ST,
-            uniqueServiceName: 'unknown'
-          }
-        } else {
-          log('create discovery')
-          let discovery: SSDP | undefined
-
-          try {
-            discovery = await ssdp()
-            discovery.on('transport:outgoing-message', (socket, message, remote) => {
-              log.trace('-> Outgoing to %s:%s via %s - %s', remote.address, remote.port, socket.type, message)
-            })
-            discovery.on('transport:incoming-message', (message, remote) => {
-              log.trace('<- Incoming from %s:%s - %s', remote.address, remote.port, message)
-            })
-
-            const signal = anySignal([shutdownController.signal, options?.signal])
-            setMaxListeners(Infinity, signal)
-
-            const result = await first(discovery.discover<InternetGatewayDevice>({
-              serviceType: ST,
-              signal
-            }))
-
-            if (result == null) {
-              throw new Error('Could not discover gateway')
-            }
-
-            log('discovered gateway %s', result.location)
-
-            expires = Date.now() + timeout
-            service = result
-          } finally {
-            await discovery?.stop()
-          }
+          service = result
+        } finally {
+          await discovery?.stop()
         }
-
-        return service
-      },
-      cancel: async () => {
-        shutdownController.abort()
       }
-    }
 
-    return discover
+      return service
+    }
   }
 }

--- a/src/pmp/index.ts
+++ b/src/pmp/index.ts
@@ -49,7 +49,6 @@ export class PMPClient extends EventEmitter implements Client {
   private reqActive: boolean
   private readonly discoverGateway: () => DiscoverGateway
   private gateway?: string
-  private cancelGatewayDiscovery?: (options?: AbortOptions) => Promise<void>
 
   static createClient (discoverGateway: () => DiscoverGateway): PMPClient {
     return new PMPClient(discoverGateway)
@@ -102,10 +101,8 @@ export class PMPClient extends EventEmitter implements Client {
     }
 
     const discoverGateway = this.discoverGateway()
-    this.cancelGatewayDiscovery = discoverGateway.cancel
 
-    const gateway = await discoverGateway.gateway(opts)
-    this.cancelGatewayDiscovery = undefined
+    const gateway = await discoverGateway(opts)
 
     this.gateway = new URL(gateway.location).host
 
@@ -135,10 +132,7 @@ export class PMPClient extends EventEmitter implements Client {
     log('Client#externalIp()')
 
     const discoverGateway = this.discoverGateway()
-    this.cancelGatewayDiscovery = discoverGateway.cancel
-
-    const gateway = await discoverGateway.gateway(options)
-    this.cancelGatewayDiscovery = undefined
+    const gateway = await discoverGateway(options)
 
     this.gateway = new URL(gateway.location).host
 
@@ -161,10 +155,6 @@ export class PMPClient extends EventEmitter implements Client {
     this.listening = false
     this.req = null
     this.reqActive = false
-
-    if (this.cancelGatewayDiscovery != null) {
-      await this.cancelGatewayDiscovery(options)
-    }
   }
 
   /**


### PR DESCRIPTION
Just pass a signal if you want to abort the search.