### PR TITLE
fix: close socket after pmp unmap

### DIFF
--- a/src/pmp/gateway.ts
+++ b/src/pmp/gateway.ts
@@ -160,10 +160,6 @@ export class PMPGateway extends EventEmitter implements Gateway {
   async stop (options?: AbortOptions): Promise<void> {
     log('Client#close()')
 
-    if (this.socket != null) {
-      this.socket.close()
-    }
-
     this.queue = []
     this.connecting = false
     this.listening = false
@@ -176,6 +172,10 @@ export class PMPGateway extends EventEmitter implements Gateway {
     }))
 
     this.refreshIntervals.clear()
+
+    if (this.socket != null) {
+      this.socket.close()
+    }
   }
 
   /**


### PR DESCRIPTION
Can't unmap ports if the socket is closed

Fixes #65