### PR TITLE
fix: log SSDP errors

### DIFF
--- a/src/upnp/discovery.ts
+++ b/src/upnp/discovery.ts
@@ -45,6 +45,9 @@ export async function * discoverGateways (options?: DiscoverOptions): AsyncGener
       log.trace('<- Incoming from %s:%s', isIPv6(remote.address) ? `[${remote.address}]` : remote.address, remote.port)
       log.trace('%s', message)
     })
+    discovery.on('error', (err) => {
+      log.error('SSDP error - %e', err)
+    })
 
     log('searching for gateways')
 


### PR DESCRIPTION
The process can crash if there's no error listener so log any SSDP errors.